### PR TITLE
Fixes phone field input issue

### DIFF
--- a/frontend/src/pages/Auth/RegisterPage/RegisterPage.js
+++ b/frontend/src/pages/Auth/RegisterPage/RegisterPage.js
@@ -56,7 +56,7 @@ const RegisterPage = () => {
                     </div>
                     <div className={styles.formGroup}>
                         <label htmlFor="phone">Phone No</label>
-                        <input value={phone} onChange={(e) => setPhone(e.target.value)} type="phone" id="phone" name="phone" required />
+                        <input value={phone} onChange={(e) => setPhone(e.target.value)} type="tel" id="phone" name="phone" required />
                     </div>
                     <div className={styles.formGroup}>
                         <label htmlFor="answer">What is your favourite Movie ?</label>

--- a/frontend/src/pages/Auth/RegisterPage/RegisterPage.js
+++ b/frontend/src/pages/Auth/RegisterPage/RegisterPage.js
@@ -56,7 +56,7 @@ const RegisterPage = () => {
                     </div>
                     <div className={styles.formGroup}>
                         <label htmlFor="phone">Phone No</label>
-                        <input value={phone} onChange={(e) => setPhone(e.target.value)} type="tel" id="phone" name="phone" required />
+                        <input value={phone} onChange={(e) => setPhone(e.target.value)} type="tel" id="phone" name="phone" pattern="[0-9]{10}" required />
                     </div>
                     <div className={styles.formGroup}>
                         <label htmlFor="answer">What is your favourite Movie ?</label>


### PR DESCRIPTION
Solves #1. 

Added [tel](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/tel) input type and basic pattern matching. Now if someone tries to enter alphabets in the phone input field they'll get a browser message. Further improvements could be made by using Javascript to prevent entering of non-numeric characters altogether, but this solution should work too.